### PR TITLE
Fix: Remove $file variable from mixin contents and rename $file argum…

### DIFF
--- a/_source/styles/_tools/_tools.typography.scss
+++ b/_source/styles/_tools/_tools.typography.scss
@@ -23,15 +23,15 @@
 }
 
 // fonts
-@mixin font($name, $file, $weight: normal) {
+@mixin font($name, $fontUrl, $weight: normal) {
 
     @font-face {
         font-family: $name;
-        src: url($fontUrl + $file + '.eot');
-        src: url($fontUrl + $file + '.eot?#iefix') format('embedded-opentype'),
-            url($fontUrl + $file + '.woff') format('woff'),
-            url($fontUrl + $file + '.ttf') format('truetype'),
-            url($fontUrl + $file + '#' + $name) format('svg');
+        src: url($fontUrl + '.eot');
+        src: url($fontUrl + '.eot?#iefix') format('embedded-opentype'),
+            url($fontUrl + '.woff') format('woff'),
+            url($fontUrl + '.ttf') format('truetype'),
+            url($fontUrl + '#' + $name) format('svg');
         font-weight: $weight;
         font-style: normal;
     }


### PR DESCRIPTION
…ent in font mixin.

The mixin contents was calling an argument that did not exist ($fontUrl). I have removed $file from the mixin contents leaving just $fontUrl. I have removed $file from the mixin arguments and replaced it with $fontUrl.
