### PR TITLE
Feature: Added filetypes as arguments to font mixin.

### DIFF
--- a/_source/styles/_tools/_tools.typography.scss
+++ b/_source/styles/_tools/_tools.typography.scss
@@ -23,15 +23,16 @@
 }
 
 // fonts
-@mixin font($name, $file, $weight: normal) {
+@mixin font($name, $file, $eot:false, $eotiefix:false, $woff:false, $ttf:false, $otf:false, $svg:false, $weight: normal) {
 
     @font-face {
         font-family: $name;
-        src: url($fontUrl + $file + '.eot');
-        src: url($fontUrl + $file + '.eot?#iefix') format('embedded-opentype'),
-            url($fontUrl + $file + '.woff') format('woff'),
-            url($fontUrl + $file + '.ttf') format('truetype'),
-            url($fontUrl + $file + '#' + $name) format('svg');
+        @if $eot == true { src: url($file + '.eot'); }
+        @if $eotiefix == true { src: url($file + '.eot?#iefix') format('embedded-opentype'); }
+        @if $woff == true { src: url($file + '.woff') format('woff'); }
+        @if $ttf == true { src: url($file + '.ttf') format('truetype'); }
+        @if $otf == true { src: url($file + '.otf') format("opentype"); }
+        @if $svg == true { src: url($file + '#' + $name) format('svg'); }
         font-weight: $weight;
         font-style: normal;
     }


### PR DESCRIPTION
The font mixin will request every type defined in src even if the file doesn't exist. To prevent wasted HTTP request I've added each font type as an argument with a default value of false. Within the mixin contents each filetype argument is checked for a value of true before outputting the src property, meaning only required filetypes are requested.

Example usage;

```
@include font('My font', 'myfonturl', $eot:true, $woff:$true);
```
